### PR TITLE
[AC-8988] Deprecate local settings

### DIFF
--- a/lib/choices.rb
+++ b/lib/choices.rb
@@ -25,6 +25,7 @@ module Choices
   def with_local_settings(filename, suffix)
     local_filename = filename.sub(/(\.\w+)?$/, "#{suffix}\\1")
     if File.exists? local_filename
+      Logger.new(STDOUT).warn("Using settings.local.yml is deprecated and will be removed. Please migrate to .env.")
       hash = load_settings_hash(local_filename)
       yield hash if hash
     end


### PR DESCRIPTION
Warns anyone still depending on this gem that it will be removed soon.

Here's a screenshot of booting Rails with and without a `settings.local.yml` file in place:
![image](https://github.com/YourAcclaim/choices/assets/78887/d3284ead-5e60-40d1-8aef-fa4f23a39dcb)
